### PR TITLE
test(c/driver/sqlite,c/driver/postgresql,c/validation): test composite primary keys

### DIFF
--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -107,6 +107,15 @@ class PostgresQuirks : public adbc_validation::DriverQuirks {
     return ddl;
   }
 
+  std::optional<std::string> CompositePrimaryKeyTableDdl(
+      std::string_view name) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += name;
+    ddl += " (id_primary_col1 SERIAL, id_primary_col2 SERIAL,";
+    ddl += " PRIMARY KEY (id_primary_col1, id_primary_col2));";
+    return ddl;
+  }
+
   std::string catalog() const override { return "postgres"; }
   std::string db_schema() const override { return "public"; }
 

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -98,6 +98,15 @@ class SqliteQuirks : public adbc_validation::DriverQuirks {
     return ddl;
   }
 
+  std::optional<std::string> CompositePrimaryKeyTableDdl(
+      std::string_view name) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += name;
+    ddl += " (id_primary_col1 INTEGER, id_primary_col2 INTEGER,";
+    ddl += " PRIMARY KEY (id_primary_col1, id_primary_col2));";
+    return ddl;
+  }
+
   bool supports_bulk_ingest(const char* mode) const override {
     return std::strcmp(mode, ADBC_INGEST_OPTION_MODE_APPEND) == 0 ||
            std::strcmp(mode, ADBC_INGEST_OPTION_MODE_CREATE) == 0;

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -86,6 +86,17 @@ class DriverQuirks {
     return std::nullopt;
   }
 
+  /// \brief Get the statement to create a table with a composite primary key,
+  /// or nullopt if not supported.
+  ///
+  /// The table should have two columns:
+  /// - "id_primary_col1" of Arrow type int64 (together forming a composite primary key)
+  /// - "id_primary_col2" of Arrow type int64 (together forming a composite primary key)
+  virtual std::optional<std::string> CompositePrimaryKeyTableDdl(
+      std::string_view name) const {
+    return std::nullopt;
+  }
+
   /// \brief Return the SQL to reference the bind parameter of the given index
   virtual std::string BindParameter(int index) const { return "?"; }
 


### PR DESCRIPTION
# Test Composite Primary Keys

## Discussion points

- `c/validation/adbc_validation.cc` line [1064] assumes a certain order of the constraint column names. An order-agnostic, but less specific, approach to test this could be
```
ASSERT_THAT(constraint_column_name,
            ::testing::AnyOf(::testing::Eq(parent_2_column_names[0]),
                             ::testing::Eq(parent_2_column_names[1])));
```

- The tests in `c/validation/adbc_validation.cc` lines [1013, 1043] erroneously always pass, independent of the table name. This is already the case for the existing Primary Key test. Fixing this could be a different PR. Example:

```
  AdbcGetObjectsDataGetTableByName(*get_objects_data, quirks()->catalog().c_str(),
                                   quirks()->db_schema().c_str(), "adbc_pkey_test");
  ASSERT_NE(table, nullptr) << "could not find adbc_pkey_test table";
```


## Working tests

The composite primary key tests fail correctly in the following ways.

### Number of table columns

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1046: Failure
Expected equality of these values:
  composite_table->n_table_columns
    Which is: 9
  2
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (87 ms)
```

```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1046: Failure
Expected equality of these values:
  composite_table->n_table_columns
    Which is: 9
  2
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```

### Table names

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1057: Failure
Expected: (parent_2_column) != (nullptr), actual: NULL vs (nullptr)
could not find column NOT_EXISTING on adbc_composite_pkey_test table
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (90 ms)
```

```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1057: Failure
Expected: (parent_2_column) != (nullptr), actual: NULL vs (nullptr)
could not find column NOT_EXISTING on adbc_composite_pkey_test table
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```

### Constraint column names
This test gives less helpful output, but is aligned with the existing primary key tests.

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1064: Failure
Expected equality of these values:
  constraint_column_name
    Which is: "id_primary_col1"
  parent_2_column_names[column_name_index]
    Which is: 0x55de7b
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (79 ms)
```

```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1064: Failure
Expected equality of these values:
  constraint_column_name
    Which is: "id_primary_col1"
  parent_2_column_names[column_name_index]
    Which is: 0x512e86
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```

### Number of table constraints

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1068: Failure
Expected equality of these values:
  composite_table->n_table_constraints
    Which is: 9
  1
expected 1 constraint on adbc_pkey_test table, found: 9
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (87 ms)
```

```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1068: Failure
Expected equality of these values:
  composite_table->n_table_constraints
    Which is: 9
  1
expected 1 constraint on adbc_pkey_test table, found: 9
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```

### Constraint type

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1075: Failure
Expected equality of these values:
  composite_constraint_type
    Which is: "UNKNOWN KEY"
  "PRIMARY KEY"
    Which is: 0x55dee9
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (87 ms)
```

```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1075: Failure
Expected equality of these values:
  composite_constraint_type
    Which is: "UNKNOWN KEY"
  "PRIMARY KEY"
    Which is: 0x512ef4
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```

### Number of constraints

```
[ RUN      ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1076: Failure
Expected equality of these values:
  composite_constraint->n_column_names
    Which is: 9
  2
expected constraint adbc_pkey_test_pkey to be applied to 2 columns, found: 9
[  FAILED  ] PostgresConnectionTest.MetadataGetObjectsPrimaryKey (79 ms)

```
```
[ RUN      ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey
/home/ole/code/arrow-adbc/c/validation/adbc_validation.cc:1076: Failure
Expected equality of these values:
  composite_constraint->n_column_names
    Which is: 9
  2
expected constraint adbc_pkey_test_pkey to be applied to 2 columns, found: 9
[  FAILED  ] SqliteConnectionTest.MetadataGetObjectsPrimaryKey (0 ms)
```
